### PR TITLE
Update for Ansible 2.8 and R 3.5 

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,10 +7,12 @@
     - "{{ansible_os_family}}.yml"
 
 - name: (Debian) configuring apt....
-  become: yes
-  become_user: root
   when: ansible_os_family == "Debian"
-  include_tasks: apt.yml
+  include_tasks:
+    file: apt.yml
+    apply:
+      become: yes
+      become_user: root
 
 - name: installing R core/base packages...
   become: yes

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,7 +2,7 @@
 apt_key_server : 'keys.gnupg.net'
 apt_key_id: '381BA480'
 
-cran_apt_repo: 'deb {{r_cran_mirror}}/bin/linux/debian {{ansible_distribution_release}}'
+cran_apt_repo: "deb {{r_cran_mirror}}/bin/linux/debian {{ansible_distribution_release}}-cran35"
 
 r_os_pkg_prefix: 'r-'
   

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -2,7 +2,7 @@
 apt_key_server: keyserver.ubuntu.com
 apt_key_id: 'E084DAB9'
 
-cran_apt_repo: 'deb {{r_cran_mirror}}/bin/linux/ubuntu {{ansible_distribution_release}}/'
+cran_apt_repo: "deb {{r_cran_mirror}}/bin/linux/ubuntu {{ansible_distribution_release}}-cran35/"
 
 r_os_pkg_prefix: 'r-'
   


### PR DESCRIPTION
## Ansible syntax update
Updates import_tasks to have become and become_user explicitly applied.  The recent changes in ansible made these invalid attributes to hang directly off import_tasks.  Instead these need to be hung off of an apply attribute.

## R repos
In short, the repos have -cran35 appended to their distribution.  E.g bionic-35 for the repo supporting R version 3.5 and up.

Closes #1 